### PR TITLE
autoconf: detect libcrypto with PKG_CHECK_MODULES

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -129,6 +129,8 @@ AC_CHECK_HEADERS([sys/types.h stdlib.h stdint.h inttypes.h malloc.h])
 #
 AC_CHECK_FUNCS([usleep fdatasync localtime_r gmtime_r localtime_s utime malloc_usable_size])
 
+PKG_PROG_PKG_CONFIG
+
 #########
 # By default, we use the amalgamation (this may be changed below...)
 #
@@ -275,8 +277,7 @@ else
         CFLAGS+=" -DSQLCIPHER_CRYPTO_OPENSSL"
         BUILD_CFLAGS+=" -DSQLCIPHER_CRYPTO_OPENSSL"
 	      AC_MSG_RESULT([openssl])
-        AC_CHECK_LIB([crypto], [HMAC_Init_ex], ,
-                     AC_MSG_ERROR([Library crypto not found. Install openssl!"]))
+        PKG_CHECK_MODULES([CRYPTO], [libcrypto])
     fi
   fi
 fi


### PR DESCRIPTION
I'm trying to compile on win32, using a static openssl.
When linking against libcryto on win32, "-lws2_32 -lgdi32 -lcrypt32" should be added to LD_FLAGS for the link to work
The lib detection fail in ./configure because of symbol missing
Using PKG_CONFIG in configure correct this problem

I didn't commit aclocal and configure, so "aclocal" and 'autoconf" should be run in order to make the change effective
