### PR TITLE
SQLCipher headers are installed into ${includedir}/sqlcipher

### DIFF
--- a/sqlcipher.pc.in
+++ b/sqlcipher.pc.in
@@ -10,4 +10,4 @@ Description: SQL database engine
 Version: @PACKAGE_VERSION@
 Libs: -L${libdir} -lsqlcipher
 Libs.private: @LIBS@
-Cflags: -I${includedir}
+Cflags: -I${includedir}/sqlcipher


### PR DESCRIPTION
This is a small correction in the sqlcipher.pc.in file.  See line #163 of Makefile.in to where the install location of the headers is set.