### PR TITLE
Fix building error by GCC 4.5.4 in AIX 5.1

### DIFF
--- a/src/crypto_impl.c
+++ b/src/crypto_impl.c
@@ -36,7 +36,7 @@
 #include "sqlcipher.h"
 #include "crypto.h"
 #ifndef OMIT_MEMLOCK
-#if defined(__unix__) || defined(__APPLE__) 
+#if defined(__unix__) || defined(__APPLE__) || defined(_AIX)
 #include <sys/mman.h>
 #elif defined(_WIN32)
 # include <windows.h>


### PR DESCRIPTION
GCC reported undefined mmap without _AIX macro.