### PR TITLE
Fix amalgamation output paths

### DIFF
--- a/sqlcipher.xcodeproj/project.pbxproj
+++ b/sqlcipher.xcodeproj/project.pbxproj
@@ -153,10 +153,9 @@
 			files = (
 			);
 			inputPaths = (
-				"$(SRCROOT)/sqlite3.c",
 			);
 			outputPaths = (
-				"$(BUILT_PRODUCTS_DIR)/libsqlcipher.a",
+				"$(SRCROOT)/sqlite3.c",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;


### PR DESCRIPTION
if had a problem compiling sqlcipher (as a dependency of SQLite.swift). It looks like the input/output paths are swapped (sqlite3.c gets generated as a result of this script / target)