### PR TITLE
Feature - Xcode Frameworks

### DIFF
--- a/macosx/Info-tvOS.plist
+++ b/macosx/Info-tvOS.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>3.3.1</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>arm64</string>
+	</array>
+</dict>
+</plist>

--- a/macosx/Info.plist
+++ b/macosx/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>3.3.1</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/macosx/SQLCipher.h
+++ b/macosx/SQLCipher.h
@@ -3,3 +3,5 @@
 
 FOUNDATION_EXPORT double SQLCipherVersionNumber;
 FOUNDATION_EXPORT const unsigned char SQLCipherVersionString[];
+
+#import "sqlite3.h"

--- a/macosx/SQLCipher.h
+++ b/macosx/SQLCipher.h
@@ -1,0 +1,5 @@
+
+@import Foundation;
+
+FOUNDATION_EXPORT double SQLCipherVersionNumber;
+FOUNDATION_EXPORT const unsigned char SQLCipherVersionString[];

--- a/sqlcipher.xcodeproj/project.pbxproj
+++ b/sqlcipher.xcodeproj/project.pbxproj
@@ -23,9 +23,10 @@
 /* Begin PBXBuildFile section */
 		4C0041A61BFC3A5000ED2AD5 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C0041A51BFC3A5000ED2AD5 /* Security.framework */; };
 		4C0041AB1BFC3A7E00ED2AD5 /* SQLCipher.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C0041A91BFC3A7E00ED2AD5 /* SQLCipher.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4C0041B41BFC3B2200ED2AD5 /* SQLCipher OSX.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C0041B31BFC3B2200ED2AD5 /* SQLCipher OSX.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4C0041BC1BFC3C7500ED2AD5 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C0041BB1BFC3C7500ED2AD5 /* Security.framework */; };
 		4C0041BD1BFC3C8300ED2AD5 /* SQLCipher.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C0041A91BFC3A7E00ED2AD5 /* SQLCipher.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4C0041CE1BFC3D3900ED2AD5 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C0041CD1BFC3D3900ED2AD5 /* Security.framework */; };
+		4C0041CF1BFC3D4000ED2AD5 /* SQLCipher.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C0041A91BFC3A7E00ED2AD5 /* SQLCipher.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9069D0A30FCE1A4D0042E34C /* sqlite3.c in Sources */ = {isa = PBXBuildFile; fileRef = 9069D0A20FCE1A4D0042E34C /* sqlite3.c */; };
 /* End PBXBuildFile section */
 
@@ -51,6 +52,13 @@
 			remoteGlobalIDString = 9069D08B0FCE185A0042E34C;
 			remoteInfo = amalgamation;
 		};
+		4C0041CB1BFC3D3000ED2AD5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9069D08B0FCE185A0042E34C;
+			remoteInfo = amalgamation;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -59,9 +67,10 @@
 		4C0041A81BFC3A7E00ED2AD5 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = macosx/Info.plist; sourceTree = "<group>"; };
 		4C0041A91BFC3A7E00ED2AD5 /* SQLCipher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SQLCipher.h; path = macosx/SQLCipher.h; sourceTree = "<group>"; };
 		4C0041B11BFC3B2200ED2AD5 /* SQLCipher.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SQLCipher.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		4C0041B31BFC3B2200ED2AD5 /* SQLCipher OSX.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SQLCipher OSX.h"; sourceTree = "<group>"; };
-		4C0041B51BFC3B2200ED2AD5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4C0041BB1BFC3C7500ED2AD5 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
+		4C0041C31BFC3CC000ED2AD5 /* SQLCipher.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SQLCipher.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4C0041CD1BFC3D3900ED2AD5 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS9.0.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
+		4C0041D01BFC3D9A00ED2AD5 /* Info-tvOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Info-tvOS.plist"; path = "macosx/Info-tvOS.plist"; sourceTree = "<group>"; };
 		9069D0A20FCE1A4D0042E34C /* sqlite3.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sqlite3.c; sourceTree = "<group>"; };
 		D2AAC046055464E500DB518D /* libsqlcipher.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libsqlcipher.a; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -82,6 +91,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		4C0041BF1BFC3CC000ED2AD5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4C0041CE1BFC3D3900ED2AD5 /* Security.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D289987405E68DCB004EDB86 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -98,7 +115,6 @@
 			children = (
 				08FB7795FE84155DC02AAC07 /* Source */,
 				4C0041A41BFC3A3800ED2AD5 /* Supporting Files */,
-				4C0041B21BFC3B2200ED2AD5 /* SQLCipher OSX */,
 				4C0041A71BFC3A5400ED2AD5 /* Frameworks */,
 				1AB674ADFE9D54B511CA2CBB /* Products */,
 			);
@@ -119,6 +135,7 @@
 				D2AAC046055464E500DB518D /* libsqlcipher.a */,
 				4C0041981BFC382400ED2AD5 /* SQLCipher.framework */,
 				4C0041B11BFC3B2200ED2AD5 /* SQLCipher.framework */,
+				4C0041C31BFC3CC000ED2AD5 /* SQLCipher.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -128,6 +145,7 @@
 			children = (
 				4C0041A91BFC3A7E00ED2AD5 /* SQLCipher.h */,
 				4C0041A81BFC3A7E00ED2AD5 /* Info.plist */,
+				4C0041D01BFC3D9A00ED2AD5 /* Info-tvOS.plist */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -135,19 +153,11 @@
 		4C0041A71BFC3A5400ED2AD5 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				4C0041CD1BFC3D3900ED2AD5 /* Security.framework */,
 				4C0041BB1BFC3C7500ED2AD5 /* Security.framework */,
 				4C0041A51BFC3A5000ED2AD5 /* Security.framework */,
 			);
 			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		4C0041B21BFC3B2200ED2AD5 /* SQLCipher OSX */ = {
-			isa = PBXGroup;
-			children = (
-				4C0041B31BFC3B2200ED2AD5 /* SQLCipher OSX.h */,
-				4C0041B51BFC3B2200ED2AD5 /* Info.plist */,
-			);
-			path = "SQLCipher OSX";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -166,7 +176,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				4C0041BD1BFC3C8300ED2AD5 /* SQLCipher.h in Headers */,
-				4C0041B41BFC3B2200ED2AD5 /* SQLCipher OSX.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4C0041C01BFC3CC000ED2AD5 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4C0041CF1BFC3D4000ED2AD5 /* SQLCipher.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -218,6 +235,25 @@
 			productReference = 4C0041B11BFC3B2200ED2AD5 /* SQLCipher.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		4C0041C21BFC3CC000ED2AD5 /* SQLCipher tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4C0041C81BFC3CC000ED2AD5 /* Build configuration list for PBXNativeTarget "SQLCipher tvOS" */;
+			buildPhases = (
+				4C0041BE1BFC3CC000ED2AD5 /* Sources */,
+				4C0041BF1BFC3CC000ED2AD5 /* Frameworks */,
+				4C0041C01BFC3CC000ED2AD5 /* Headers */,
+				4C0041C11BFC3CC000ED2AD5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				4C0041CC1BFC3D3000ED2AD5 /* PBXTargetDependency */,
+			);
+			name = "SQLCipher tvOS";
+			productName = "SQLCipher tvOS";
+			productReference = 4C0041C31BFC3CC000ED2AD5 /* SQLCipher.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		D2AAC045055464E500DB518D /* sqlcipher */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 1DEB91EB08733DB70010E9CD /* Build configuration list for PBXNativeTarget "sqlcipher" */;
@@ -250,6 +286,9 @@
 					4C0041B01BFC3B2200ED2AD5 = {
 						CreatedOnToolsVersion = 7.1;
 					};
+					4C0041C21BFC3CC000ED2AD5 = {
+						CreatedOnToolsVersion = 7.1;
+					};
 				};
 			};
 			buildConfigurationList = 1DEB91EF08733DB70010E9CD /* Build configuration list for PBXProject "sqlcipher" */;
@@ -268,6 +307,7 @@
 			targets = (
 				4C0041971BFC382400ED2AD5 /* SQLCipher iOS */,
 				4C0041B01BFC3B2200ED2AD5 /* SQLCipher OSX */,
+				4C0041C21BFC3CC000ED2AD5 /* SQLCipher tvOS */,
 				D2AAC045055464E500DB518D /* sqlcipher */,
 				9069D08B0FCE185A0042E34C /* amalgamation */,
 			);
@@ -283,6 +323,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		4C0041AF1BFC3B2200ED2AD5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4C0041C11BFC3CC000ED2AD5 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -323,6 +370,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		4C0041BE1BFC3CC000ED2AD5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D2AAC044055464E500DB518D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -348,6 +402,11 @@
 			isa = PBXTargetDependency;
 			target = 9069D08B0FCE185A0042E34C /* amalgamation */;
 			targetProxy = 4C0041B91BFC3C6E00ED2AD5 /* PBXContainerItemProxy */;
+		};
+		4C0041CC1BFC3D3000ED2AD5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9069D08B0FCE185A0042E34C /* amalgamation */;
+			targetProxy = 4C0041CB1BFC3D3000ED2AD5 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -738,6 +797,132 @@
 			};
 			name = Release;
 		};
+		4C0041C91BFC3CC000ED2AD5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				"ARCHS[sdk=iphoneos*]" = "$(ARCHS_STANDARD)";
+				"ARCHS[sdk=iphonesimulator*]" = "$(ARCHS_STANDARD)";
+				"ARCHS[sdk=macosx*]" = "$(ARCHS_STANDARD)";
+				BITCODE_GENERATION_MODE = marker;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = "macosx/Info-tvOS.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_CFLAGS = (
+					"-DSQLITE_HAS_CODEC",
+					"-DSQLITE_TEMP_STORE=2",
+					"-DSQLITE_THREADSAFE",
+					"-DSQLCIPHER_CRYPTO_CC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = net.zetetic.SQLCipher;
+				PRODUCT_NAME = SQLCipher;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				VALID_ARCHS = arm64;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		4C0041CA1BFC3CC000ED2AD5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				"ARCHS[sdk=iphoneos*]" = "$(ARCHS_STANDARD)";
+				"ARCHS[sdk=iphonesimulator*]" = "$(ARCHS_STANDARD)";
+				"ARCHS[sdk=macosx*]" = "$(ARCHS_STANDARD)";
+				BITCODE_GENERATION_MODE = bitcode;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = "macosx/Info-tvOS.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_CFLAGS = (
+					"-DSQLITE_HAS_CODEC",
+					"-DSQLITE_TEMP_STORE=2",
+					"-DSQLITE_THREADSAFE",
+					"-DSQLCIPHER_CRYPTO_CC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = net.zetetic.SQLCipher;
+				PRODUCT_NAME = SQLCipher;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				VALIDATE_PRODUCT = YES;
+				VALID_ARCHS = arm64;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 		9069D08C0FCE185A0042E34C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -798,6 +983,14 @@
 			buildConfigurations = (
 				4C0041B71BFC3B2200ED2AD5 /* Debug */,
 				4C0041B81BFC3B2200ED2AD5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		4C0041C81BFC3CC000ED2AD5 /* Build configuration list for PBXNativeTarget "SQLCipher tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4C0041C91BFC3CC000ED2AD5 /* Debug */,
+				4C0041CA1BFC3CC000ED2AD5 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 		};

--- a/sqlcipher.xcodeproj/project.pbxproj
+++ b/sqlcipher.xcodeproj/project.pbxproj
@@ -23,6 +23,9 @@
 /* Begin PBXBuildFile section */
 		4C0041A61BFC3A5000ED2AD5 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C0041A51BFC3A5000ED2AD5 /* Security.framework */; };
 		4C0041AB1BFC3A7E00ED2AD5 /* SQLCipher.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C0041A91BFC3A7E00ED2AD5 /* SQLCipher.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4C0041B41BFC3B2200ED2AD5 /* SQLCipher OSX.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C0041B31BFC3B2200ED2AD5 /* SQLCipher OSX.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4C0041BC1BFC3C7500ED2AD5 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C0041BB1BFC3C7500ED2AD5 /* Security.framework */; };
+		4C0041BD1BFC3C8300ED2AD5 /* SQLCipher.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C0041A91BFC3A7E00ED2AD5 /* SQLCipher.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9069D0A30FCE1A4D0042E34C /* sqlite3.c in Sources */ = {isa = PBXBuildFile; fileRef = 9069D0A20FCE1A4D0042E34C /* sqlite3.c */; };
 /* End PBXBuildFile section */
 
@@ -41,6 +44,13 @@
 			remoteGlobalIDString = 9069D08B0FCE185A0042E34C;
 			remoteInfo = amalgamation;
 		};
+		4C0041B91BFC3C6E00ED2AD5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9069D08B0FCE185A0042E34C;
+			remoteInfo = amalgamation;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -48,6 +58,10 @@
 		4C0041A51BFC3A5000ED2AD5 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		4C0041A81BFC3A7E00ED2AD5 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = macosx/Info.plist; sourceTree = "<group>"; };
 		4C0041A91BFC3A7E00ED2AD5 /* SQLCipher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SQLCipher.h; path = macosx/SQLCipher.h; sourceTree = "<group>"; };
+		4C0041B11BFC3B2200ED2AD5 /* SQLCipher.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SQLCipher.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4C0041B31BFC3B2200ED2AD5 /* SQLCipher OSX.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SQLCipher OSX.h"; sourceTree = "<group>"; };
+		4C0041B51BFC3B2200ED2AD5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4C0041BB1BFC3C7500ED2AD5 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
 		9069D0A20FCE1A4D0042E34C /* sqlite3.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sqlite3.c; sourceTree = "<group>"; };
 		D2AAC046055464E500DB518D /* libsqlcipher.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libsqlcipher.a; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -57,6 +71,14 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4C0041AD1BFC3B2200ED2AD5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4C0041BC1BFC3C7500ED2AD5 /* Security.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -76,6 +98,7 @@
 			children = (
 				08FB7795FE84155DC02AAC07 /* Source */,
 				4C0041A41BFC3A3800ED2AD5 /* Supporting Files */,
+				4C0041B21BFC3B2200ED2AD5 /* SQLCipher OSX */,
 				4C0041A71BFC3A5400ED2AD5 /* Frameworks */,
 				1AB674ADFE9D54B511CA2CBB /* Products */,
 			);
@@ -95,6 +118,7 @@
 			children = (
 				D2AAC046055464E500DB518D /* libsqlcipher.a */,
 				4C0041981BFC382400ED2AD5 /* SQLCipher.framework */,
+				4C0041B11BFC3B2200ED2AD5 /* SQLCipher.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -111,9 +135,19 @@
 		4C0041A71BFC3A5400ED2AD5 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				4C0041BB1BFC3C7500ED2AD5 /* Security.framework */,
 				4C0041A51BFC3A5000ED2AD5 /* Security.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		4C0041B21BFC3B2200ED2AD5 /* SQLCipher OSX */ = {
+			isa = PBXGroup;
+			children = (
+				4C0041B31BFC3B2200ED2AD5 /* SQLCipher OSX.h */,
+				4C0041B51BFC3B2200ED2AD5 /* Info.plist */,
+			);
+			path = "SQLCipher OSX";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -124,6 +158,15 @@
 			buildActionMask = 2147483647;
 			files = (
 				4C0041AB1BFC3A7E00ED2AD5 /* SQLCipher.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4C0041AE1BFC3B2200ED2AD5 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4C0041BD1BFC3C8300ED2AD5 /* SQLCipher.h in Headers */,
+				4C0041B41BFC3B2200ED2AD5 /* SQLCipher OSX.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -156,6 +199,25 @@
 			productReference = 4C0041981BFC382400ED2AD5 /* SQLCipher.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		4C0041B01BFC3B2200ED2AD5 /* SQLCipher OSX */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4C0041B61BFC3B2200ED2AD5 /* Build configuration list for PBXNativeTarget "SQLCipher OSX" */;
+			buildPhases = (
+				4C0041AC1BFC3B2200ED2AD5 /* Sources */,
+				4C0041AD1BFC3B2200ED2AD5 /* Frameworks */,
+				4C0041AE1BFC3B2200ED2AD5 /* Headers */,
+				4C0041AF1BFC3B2200ED2AD5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				4C0041BA1BFC3C6E00ED2AD5 /* PBXTargetDependency */,
+			);
+			name = "SQLCipher OSX";
+			productName = "SQLCipher OSX";
+			productReference = 4C0041B11BFC3B2200ED2AD5 /* SQLCipher.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		D2AAC045055464E500DB518D /* sqlcipher */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 1DEB91EB08733DB70010E9CD /* Build configuration list for PBXNativeTarget "sqlcipher" */;
@@ -185,6 +247,9 @@
 					4C0041971BFC382400ED2AD5 = {
 						CreatedOnToolsVersion = 7.1;
 					};
+					4C0041B01BFC3B2200ED2AD5 = {
+						CreatedOnToolsVersion = 7.1;
+					};
 				};
 			};
 			buildConfigurationList = 1DEB91EF08733DB70010E9CD /* Build configuration list for PBXProject "sqlcipher" */;
@@ -202,6 +267,7 @@
 			projectRoot = "";
 			targets = (
 				4C0041971BFC382400ED2AD5 /* SQLCipher iOS */,
+				4C0041B01BFC3B2200ED2AD5 /* SQLCipher OSX */,
 				D2AAC045055464E500DB518D /* sqlcipher */,
 				9069D08B0FCE185A0042E34C /* amalgamation */,
 			);
@@ -210,6 +276,13 @@
 
 /* Begin PBXResourcesBuildPhase section */
 		4C0041961BFC382400ED2AD5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4C0041AF1BFC3B2200ED2AD5 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -243,6 +316,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		4C0041AC1BFC3B2200ED2AD5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D2AAC044055464E500DB518D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -263,6 +343,11 @@
 			isa = PBXTargetDependency;
 			target = 9069D08B0FCE185A0042E34C /* amalgamation */;
 			targetProxy = 4C0041A11BFC392D00ED2AD5 /* PBXContainerItemProxy */;
+		};
+		4C0041BA1BFC3C6E00ED2AD5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9069D08B0FCE185A0042E34C /* amalgamation */;
+			targetProxy = 4C0041B91BFC3C6E00ED2AD5 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -388,7 +473,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				"ARCHS[sdk=iphoneos*]" = "$(ARCHS_STANDARD)";
 				"ARCHS[sdk=iphonesimulator*]" = "$(ARCHS_STANDARD)";
 				"ARCHS[sdk=macosx*]" = "$(ARCHS_STANDARD)";
 				BITCODE_GENERATION_MODE = marker;
@@ -519,6 +603,141 @@
 			};
 			name = Release;
 		};
+		4C0041B71BFC3B2200ED2AD5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				"ARCHS[sdk=iphoneos*]" = "$(ARCHS_STANDARD)";
+				"ARCHS[sdk=iphonesimulator*]" = "$(ARCHS_STANDARD)";
+				"ARCHS[sdk=macosx*]" = "$(ARCHS_STANDARD)";
+				BITCODE_GENERATION_MODE = marker;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = macosx/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_CFLAGS = (
+					"-DSQLITE_HAS_CODEC",
+					"-DSQLITE_TEMP_STORE=2",
+					"-DSQLITE_THREADSAFE",
+					"-DSQLCIPHER_CRYPTO_CC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = net.zetetic.SQLCipher;
+				PRODUCT_NAME = SQLCipher;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				VALID_ARCHS = "i386 x86_64";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		4C0041B81BFC3B2200ED2AD5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				"ARCHS[sdk=iphoneos*]" = "$(ARCHS_STANDARD)";
+				"ARCHS[sdk=iphonesimulator*]" = "$(ARCHS_STANDARD)";
+				"ARCHS[sdk=macosx*]" = "$(ARCHS_STANDARD)";
+				BITCODE_GENERATION_MODE = bitcode;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = macosx/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_CFLAGS = (
+					"-DSQLITE_HAS_CODEC",
+					"-DSQLITE_TEMP_STORE=2",
+					"-DSQLITE_THREADSAFE",
+					"-DSQLCIPHER_CRYPTO_CC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = net.zetetic.SQLCipher;
+				PRODUCT_NAME = SQLCipher;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = macosx;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				VALID_ARCHS = "i386 x86_64";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
 		9069D08C0FCE185A0042E34C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -571,6 +790,14 @@
 			buildConfigurations = (
 				4C00419E1BFC382500ED2AD5 /* Debug */,
 				4C00419F1BFC382500ED2AD5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		4C0041B61BFC3B2200ED2AD5 /* Build configuration list for PBXNativeTarget "SQLCipher OSX" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4C0041B71BFC3B2200ED2AD5 /* Debug */,
+				4C0041B81BFC3B2200ED2AD5 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 		};

--- a/sqlcipher.xcodeproj/project.pbxproj
+++ b/sqlcipher.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		4C0041BD1BFC3C8300ED2AD5 /* SQLCipher.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C0041A91BFC3A7E00ED2AD5 /* SQLCipher.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4C0041CE1BFC3D3900ED2AD5 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C0041CD1BFC3D3900ED2AD5 /* Security.framework */; };
 		4C0041CF1BFC3D4000ED2AD5 /* SQLCipher.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C0041A91BFC3A7E00ED2AD5 /* SQLCipher.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4C0041E11BFC3F0800ED2AD5 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C0041E01BFC3F0800ED2AD5 /* Security.framework */; };
+		4C0041E21BFC3F5A00ED2AD5 /* SQLCipher.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C0041A91BFC3A7E00ED2AD5 /* SQLCipher.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9069D0A30FCE1A4D0042E34C /* sqlite3.c in Sources */ = {isa = PBXBuildFile; fileRef = 9069D0A20FCE1A4D0042E34C /* sqlite3.c */; };
 /* End PBXBuildFile section */
 
@@ -59,6 +61,13 @@
 			remoteGlobalIDString = 9069D08B0FCE185A0042E34C;
 			remoteInfo = amalgamation;
 		};
+		4C0041DE1BFC3F0100ED2AD5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9069D08B0FCE185A0042E34C;
+			remoteInfo = amalgamation;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -71,6 +80,8 @@
 		4C0041C31BFC3CC000ED2AD5 /* SQLCipher.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SQLCipher.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4C0041CD1BFC3D3900ED2AD5 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS9.0.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
 		4C0041D01BFC3D9A00ED2AD5 /* Info-tvOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Info-tvOS.plist"; path = "macosx/Info-tvOS.plist"; sourceTree = "<group>"; };
+		4C0041D61BFC3E2500ED2AD5 /* SQLCipher.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SQLCipher.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4C0041E01BFC3F0800ED2AD5 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/WatchOS.platform/Developer/SDKs/WatchOS2.0.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
 		9069D0A20FCE1A4D0042E34C /* sqlite3.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sqlite3.c; sourceTree = "<group>"; };
 		D2AAC046055464E500DB518D /* libsqlcipher.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libsqlcipher.a; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -96,6 +107,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				4C0041CE1BFC3D3900ED2AD5 /* Security.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4C0041D21BFC3E2500ED2AD5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4C0041E11BFC3F0800ED2AD5 /* Security.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -136,6 +155,7 @@
 				4C0041981BFC382400ED2AD5 /* SQLCipher.framework */,
 				4C0041B11BFC3B2200ED2AD5 /* SQLCipher.framework */,
 				4C0041C31BFC3CC000ED2AD5 /* SQLCipher.framework */,
+				4C0041D61BFC3E2500ED2AD5 /* SQLCipher.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -153,6 +173,7 @@
 		4C0041A71BFC3A5400ED2AD5 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				4C0041E01BFC3F0800ED2AD5 /* Security.framework */,
 				4C0041CD1BFC3D3900ED2AD5 /* Security.framework */,
 				4C0041BB1BFC3C7500ED2AD5 /* Security.framework */,
 				4C0041A51BFC3A5000ED2AD5 /* Security.framework */,
@@ -184,6 +205,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				4C0041CF1BFC3D4000ED2AD5 /* SQLCipher.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4C0041D31BFC3E2500ED2AD5 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4C0041E21BFC3F5A00ED2AD5 /* SQLCipher.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -254,6 +283,25 @@
 			productReference = 4C0041C31BFC3CC000ED2AD5 /* SQLCipher.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		4C0041D51BFC3E2500ED2AD5 /* SQLCipher watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4C0041DB1BFC3E2600ED2AD5 /* Build configuration list for PBXNativeTarget "SQLCipher watchOS" */;
+			buildPhases = (
+				4C0041D11BFC3E2500ED2AD5 /* Sources */,
+				4C0041D21BFC3E2500ED2AD5 /* Frameworks */,
+				4C0041D31BFC3E2500ED2AD5 /* Headers */,
+				4C0041D41BFC3E2500ED2AD5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				4C0041DF1BFC3F0100ED2AD5 /* PBXTargetDependency */,
+			);
+			name = "SQLCipher watchOS";
+			productName = SQLCipher;
+			productReference = 4C0041D61BFC3E2500ED2AD5 /* SQLCipher.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		D2AAC045055464E500DB518D /* sqlcipher */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 1DEB91EB08733DB70010E9CD /* Build configuration list for PBXNativeTarget "sqlcipher" */;
@@ -289,6 +337,9 @@
 					4C0041C21BFC3CC000ED2AD5 = {
 						CreatedOnToolsVersion = 7.1;
 					};
+					4C0041D51BFC3E2500ED2AD5 = {
+						CreatedOnToolsVersion = 7.1;
+					};
 				};
 			};
 			buildConfigurationList = 1DEB91EF08733DB70010E9CD /* Build configuration list for PBXProject "sqlcipher" */;
@@ -308,6 +359,7 @@
 				4C0041971BFC382400ED2AD5 /* SQLCipher iOS */,
 				4C0041B01BFC3B2200ED2AD5 /* SQLCipher OSX */,
 				4C0041C21BFC3CC000ED2AD5 /* SQLCipher tvOS */,
+				4C0041D51BFC3E2500ED2AD5 /* SQLCipher watchOS */,
 				D2AAC045055464E500DB518D /* sqlcipher */,
 				9069D08B0FCE185A0042E34C /* amalgamation */,
 			);
@@ -330,6 +382,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		4C0041C11BFC3CC000ED2AD5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4C0041D41BFC3E2500ED2AD5 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -377,6 +436,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		4C0041D11BFC3E2500ED2AD5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D2AAC044055464E500DB518D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -407,6 +473,11 @@
 			isa = PBXTargetDependency;
 			target = 9069D08B0FCE185A0042E34C /* amalgamation */;
 			targetProxy = 4C0041CB1BFC3D3000ED2AD5 /* PBXContainerItemProxy */;
+		};
+		4C0041DF1BFC3F0100ED2AD5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9069D08B0FCE185A0042E34C /* amalgamation */;
+			targetProxy = 4C0041DE1BFC3F0100ED2AD5 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -840,7 +911,9 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				INFOPLIST_FILE = "macosx/Info-tvOS.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				OTHER_CFLAGS = (
 					"-DSQLITE_HAS_CODEC",
@@ -859,6 +932,7 @@
 				VALID_ARCHS = arm64;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Debug;
 		};
@@ -901,7 +975,9 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				INFOPLIST_FILE = "macosx/Info-tvOS.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_CFLAGS = (
 					"-DSQLITE_HAS_CODEC",
@@ -920,6 +996,141 @@
 				VALID_ARCHS = arm64;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+		4C0041DC1BFC3E2600ED2AD5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				"ARCHS[sdk=iphoneos*]" = "$(ARCHS_STANDARD)";
+				"ARCHS[sdk=iphonesimulator*]" = "$(ARCHS_STANDARD)";
+				"ARCHS[sdk=macosx*]" = "$(ARCHS_STANDARD)";
+				BITCODE_GENERATION_MODE = marker;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = macosx/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_CFLAGS = (
+					"-DSQLITE_HAS_CODEC",
+					"-DSQLITE_TEMP_STORE=2",
+					"-DSQLITE_THREADSAFE",
+					"-DSQLCIPHER_CRYPTO_CC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = net.zetetic.SQLCipher;
+				PRODUCT_NAME = SQLCipher;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "watchsimulator watchos";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = 4;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				VALID_ARCHS = armv7k;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		4C0041DD1BFC3E2600ED2AD5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				"ARCHS[sdk=iphoneos*]" = "$(ARCHS_STANDARD)";
+				"ARCHS[sdk=iphonesimulator*]" = "$(ARCHS_STANDARD)";
+				"ARCHS[sdk=macosx*]" = "$(ARCHS_STANDARD)";
+				BITCODE_GENERATION_MODE = bitcode;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = macosx/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_CFLAGS = (
+					"-DSQLITE_HAS_CODEC",
+					"-DSQLITE_TEMP_STORE=2",
+					"-DSQLITE_THREADSAFE",
+					"-DSQLCIPHER_CRYPTO_CC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = net.zetetic.SQLCipher;
+				PRODUCT_NAME = SQLCipher;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "watchsimulator watchos";
+				TARGETED_DEVICE_FAMILY = 4;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				VALIDATE_PRODUCT = YES;
+				VALID_ARCHS = armv7k;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Release;
 		};
@@ -991,6 +1202,14 @@
 			buildConfigurations = (
 				4C0041C91BFC3CC000ED2AD5 /* Debug */,
 				4C0041CA1BFC3CC000ED2AD5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		4C0041DB1BFC3E2600ED2AD5 /* Build configuration list for PBXNativeTarget "SQLCipher watchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4C0041DC1BFC3E2600ED2AD5 /* Debug */,
+				4C0041DD1BFC3E2600ED2AD5 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 		};

--- a/sqlcipher.xcodeproj/project.pbxproj
+++ b/sqlcipher.xcodeproj/project.pbxproj
@@ -29,6 +29,14 @@
 		4C0041CF1BFC3D4000ED2AD5 /* SQLCipher.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C0041A91BFC3A7E00ED2AD5 /* SQLCipher.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4C0041E11BFC3F0800ED2AD5 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C0041E01BFC3F0800ED2AD5 /* Security.framework */; };
 		4C0041E21BFC3F5A00ED2AD5 /* SQLCipher.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C0041A91BFC3A7E00ED2AD5 /* SQLCipher.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4C0041FA1BFC46A600ED2AD5 /* sqlite3.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C0041F91BFC46A600ED2AD5 /* sqlite3.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4C0041FB1BFC46A600ED2AD5 /* sqlite3.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C0041F91BFC46A600ED2AD5 /* sqlite3.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4C0041FC1BFC46A600ED2AD5 /* sqlite3.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C0041F91BFC46A600ED2AD5 /* sqlite3.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4C0041FD1BFC46A600ED2AD5 /* sqlite3.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C0041F91BFC46A600ED2AD5 /* sqlite3.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4C0041FE1BFC474700ED2AD5 /* sqlite3.c in Sources */ = {isa = PBXBuildFile; fileRef = 9069D0A20FCE1A4D0042E34C /* sqlite3.c */; };
+		4C0041FF1BFC474700ED2AD5 /* sqlite3.c in Sources */ = {isa = PBXBuildFile; fileRef = 9069D0A20FCE1A4D0042E34C /* sqlite3.c */; };
+		4C0042001BFC474700ED2AD5 /* sqlite3.c in Sources */ = {isa = PBXBuildFile; fileRef = 9069D0A20FCE1A4D0042E34C /* sqlite3.c */; };
+		4C0042011BFC474800ED2AD5 /* sqlite3.c in Sources */ = {isa = PBXBuildFile; fileRef = 9069D0A20FCE1A4D0042E34C /* sqlite3.c */; };
 		9069D0A30FCE1A4D0042E34C /* sqlite3.c in Sources */ = {isa = PBXBuildFile; fileRef = 9069D0A20FCE1A4D0042E34C /* sqlite3.c */; };
 /* End PBXBuildFile section */
 
@@ -82,6 +90,7 @@
 		4C0041D01BFC3D9A00ED2AD5 /* Info-tvOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Info-tvOS.plist"; path = "macosx/Info-tvOS.plist"; sourceTree = "<group>"; };
 		4C0041D61BFC3E2500ED2AD5 /* SQLCipher.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SQLCipher.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4C0041E01BFC3F0800ED2AD5 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/WatchOS.platform/Developer/SDKs/WatchOS2.0.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
+		4C0041F91BFC46A600ED2AD5 /* sqlite3.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sqlite3.h; sourceTree = "<group>"; };
 		9069D0A20FCE1A4D0042E34C /* sqlite3.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sqlite3.c; sourceTree = "<group>"; };
 		D2AAC046055464E500DB518D /* libsqlcipher.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libsqlcipher.a; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -144,6 +153,7 @@
 			isa = PBXGroup;
 			children = (
 				9069D0A20FCE1A4D0042E34C /* sqlite3.c */,
+				4C0041F91BFC46A600ED2AD5 /* sqlite3.h */,
 			);
 			name = Source;
 			sourceTree = "<group>";
@@ -188,6 +198,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4C0041FA1BFC46A600ED2AD5 /* sqlite3.h in Headers */,
 				4C0041AB1BFC3A7E00ED2AD5 /* SQLCipher.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -196,6 +207,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4C0041FB1BFC46A600ED2AD5 /* sqlite3.h in Headers */,
 				4C0041BD1BFC3C8300ED2AD5 /* SQLCipher.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -204,6 +216,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4C0041FC1BFC46A600ED2AD5 /* sqlite3.h in Headers */,
 				4C0041CF1BFC3D4000ED2AD5 /* SQLCipher.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -212,6 +225,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4C0041FD1BFC46A600ED2AD5 /* sqlite3.h in Headers */,
 				4C0041E21BFC3F5A00ED2AD5 /* SQLCipher.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -419,6 +433,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4C0041FE1BFC474700ED2AD5 /* sqlite3.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -426,6 +441,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4C0041FF1BFC474700ED2AD5 /* sqlite3.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -433,6 +449,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4C0042001BFC474700ED2AD5 /* sqlite3.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -440,6 +457,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4C0042011BFC474800ED2AD5 /* sqlite3.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -638,10 +656,17 @@
 					"$(inherited)",
 				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = YES;
+				GCC_WARN_ABOUT_INVALID_OFFSETOF_MACRO = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_CHECK_SWITCH_STATEMENTS = YES;
+				GCC_WARN_MISSING_PARENTHESES = YES;
+				GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = YES;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VALUE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = macosx/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
@@ -653,6 +678,12 @@
 					"-DSQLITE_TEMP_STORE=2",
 					"-DSQLITE_THREADSAFE",
 					"-DSQLCIPHER_CRYPTO_CC",
+					"-Wno-ambiguous-macro",
+					"-Wno-#warnings",
+					"-Wno-conversion",
+					"-Wno-unused-const-variable",
+					"-Wno-unused-function",
+					"-Wno-unreachable-code",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = net.zetetic.SQLCipher;
 				PRODUCT_NAME = SQLCipher;
@@ -703,10 +734,17 @@
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = YES;
+				GCC_WARN_ABOUT_INVALID_OFFSETOF_MACRO = NO;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_CHECK_SWITCH_STATEMENTS = YES;
+				GCC_WARN_MISSING_PARENTHESES = YES;
+				GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = YES;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VALUE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = macosx/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
@@ -718,6 +756,12 @@
 					"-DSQLITE_TEMP_STORE=2",
 					"-DSQLITE_THREADSAFE",
 					"-DSQLCIPHER_CRYPTO_CC",
+					"-Wno-ambiguous-macro",
+					"-Wno-#warnings",
+					"-Wno-conversion",
+					"-Wno-unused-const-variable",
+					"-Wno-unused-function",
+					"-Wno-unreachable-code",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = net.zetetic.SQLCipher;
 				PRODUCT_NAME = SQLCipher;
@@ -788,6 +832,12 @@
 					"-DSQLITE_TEMP_STORE=2",
 					"-DSQLITE_THREADSAFE",
 					"-DSQLCIPHER_CRYPTO_CC",
+					"-Wno-ambiguous-macro",
+					"-Wno-#warnings",
+					"-Wno-conversion",
+					"-Wno-unused-const-variable",
+					"-Wno-unused-function",
+					"-Wno-unreachable-code",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = net.zetetic.SQLCipher;
 				PRODUCT_NAME = SQLCipher;
@@ -854,6 +904,12 @@
 					"-DSQLITE_TEMP_STORE=2",
 					"-DSQLITE_THREADSAFE",
 					"-DSQLCIPHER_CRYPTO_CC",
+					"-Wno-ambiguous-macro",
+					"-Wno-#warnings",
+					"-Wno-conversion",
+					"-Wno-unused-const-variable",
+					"-Wno-unused-function",
+					"-Wno-unreachable-code",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = net.zetetic.SQLCipher;
 				PRODUCT_NAME = SQLCipher;
@@ -920,6 +976,12 @@
 					"-DSQLITE_TEMP_STORE=2",
 					"-DSQLITE_THREADSAFE",
 					"-DSQLCIPHER_CRYPTO_CC",
+					"-Wno-ambiguous-macro",
+					"-Wno-#warnings",
+					"-Wno-conversion",
+					"-Wno-unused-const-variable",
+					"-Wno-unused-function",
+					"-Wno-unreachable-code",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = net.zetetic.SQLCipher;
 				PRODUCT_NAME = SQLCipher;
@@ -984,6 +1046,12 @@
 					"-DSQLITE_TEMP_STORE=2",
 					"-DSQLITE_THREADSAFE",
 					"-DSQLCIPHER_CRYPTO_CC",
+					"-Wno-ambiguous-macro",
+					"-Wno-#warnings",
+					"-Wno-conversion",
+					"-Wno-unused-const-variable",
+					"-Wno-unused-function",
+					"-Wno-unreachable-code",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = net.zetetic.SQLCipher;
 				PRODUCT_NAME = SQLCipher;
@@ -1053,6 +1121,12 @@
 					"-DSQLITE_TEMP_STORE=2",
 					"-DSQLITE_THREADSAFE",
 					"-DSQLCIPHER_CRYPTO_CC",
+					"-Wno-ambiguous-macro",
+					"-Wno-#warnings",
+					"-Wno-conversion",
+					"-Wno-unused-const-variable",
+					"-Wno-unused-function",
+					"-Wno-unreachable-code",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = net.zetetic.SQLCipher;
 				PRODUCT_NAME = SQLCipher;
@@ -1118,6 +1192,12 @@
 					"-DSQLITE_TEMP_STORE=2",
 					"-DSQLITE_THREADSAFE",
 					"-DSQLCIPHER_CRYPTO_CC",
+					"-Wno-ambiguous-macro",
+					"-Wno-#warnings",
+					"-Wno-conversion",
+					"-Wno-unused-const-variable",
+					"-Wno-unused-function",
+					"-Wno-unreachable-code",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = net.zetetic.SQLCipher;
 				PRODUCT_NAME = SQLCipher;
@@ -1188,6 +1268,7 @@
 				4C00419F1BFC382500ED2AD5 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		4C0041B61BFC3B2200ED2AD5 /* Build configuration list for PBXNativeTarget "SQLCipher OSX" */ = {
 			isa = XCConfigurationList;
@@ -1196,6 +1277,7 @@
 				4C0041B81BFC3B2200ED2AD5 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		4C0041C81BFC3CC000ED2AD5 /* Build configuration list for PBXNativeTarget "SQLCipher tvOS" */ = {
 			isa = XCConfigurationList;
@@ -1204,6 +1286,7 @@
 				4C0041CA1BFC3CC000ED2AD5 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		4C0041DB1BFC3E2600ED2AD5 /* Build configuration list for PBXNativeTarget "SQLCipher watchOS" */ = {
 			isa = XCConfigurationList;
@@ -1212,6 +1295,7 @@
 				4C0041DD1BFC3E2600ED2AD5 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		9069D0900FCE18970042E34C /* Build configuration list for PBXAggregateTarget "amalgamation" */ = {
 			isa = XCConfigurationList;

--- a/sqlcipher.xcodeproj/project.pbxproj
+++ b/sqlcipher.xcodeproj/project.pbxproj
@@ -21,7 +21,8 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		28B46E6317CD07A700672510 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28B46E6217CD07A600672510 /* Security.framework */; };
+		4C0041A61BFC3A5000ED2AD5 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C0041A51BFC3A5000ED2AD5 /* Security.framework */; };
+		4C0041AB1BFC3A7E00ED2AD5 /* SQLCipher.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C0041A91BFC3A7E00ED2AD5 /* SQLCipher.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9069D0A30FCE1A4D0042E34C /* sqlite3.c in Sources */ = {isa = PBXBuildFile; fileRef = 9069D0A20FCE1A4D0042E34C /* sqlite3.c */; };
 /* End PBXBuildFile section */
 
@@ -33,20 +34,37 @@
 			remoteGlobalIDString = 9069D08B0FCE185A0042E34C;
 			remoteInfo = amalgamation;
 		};
+		4C0041A11BFC392D00ED2AD5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9069D08B0FCE185A0042E34C;
+			remoteInfo = amalgamation;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		28B46E6217CD07A600672510 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+		4C0041981BFC382400ED2AD5 /* SQLCipher.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SQLCipher.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4C0041A51BFC3A5000ED2AD5 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
+		4C0041A81BFC3A7E00ED2AD5 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = macosx/Info.plist; sourceTree = "<group>"; };
+		4C0041A91BFC3A7E00ED2AD5 /* SQLCipher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SQLCipher.h; path = macosx/SQLCipher.h; sourceTree = "<group>"; };
 		9069D0A20FCE1A4D0042E34C /* sqlite3.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sqlite3.c; sourceTree = "<group>"; };
 		D2AAC046055464E500DB518D /* libsqlcipher.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libsqlcipher.a; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		4C0041941BFC382400ED2AD5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D289987405E68DCB004EDB86 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				28B46E6317CD07A700672510 /* Security.framework in Frameworks */,
+				4C0041A61BFC3A5000ED2AD5 /* Security.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -56,9 +74,9 @@
 		08FB7794FE84155DC02AAC07 /* sqlcipher */ = {
 			isa = PBXGroup;
 			children = (
-				28B46E6217CD07A600672510 /* Security.framework */,
 				08FB7795FE84155DC02AAC07 /* Source */,
-				C6A0FF2B0290797F04C91782 /* Documentation */,
+				4C0041A41BFC3A3800ED2AD5 /* Supporting Files */,
+				4C0041A71BFC3A5400ED2AD5 /* Frameworks */,
 				1AB674ADFE9D54B511CA2CBB /* Products */,
 			);
 			name = sqlcipher;
@@ -76,20 +94,39 @@
 			isa = PBXGroup;
 			children = (
 				D2AAC046055464E500DB518D /* libsqlcipher.a */,
+				4C0041981BFC382400ED2AD5 /* SQLCipher.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
 		};
-		C6A0FF2B0290797F04C91782 /* Documentation */ = {
+		4C0041A41BFC3A3800ED2AD5 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				4C0041A91BFC3A7E00ED2AD5 /* SQLCipher.h */,
+				4C0041A81BFC3A7E00ED2AD5 /* Info.plist */,
 			);
-			name = Documentation;
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		4C0041A71BFC3A5400ED2AD5 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				4C0041A51BFC3A5000ED2AD5 /* Security.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		4C0041951BFC382400ED2AD5 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4C0041AB1BFC3A7E00ED2AD5 /* SQLCipher.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D2AAC043055464E500DB518D /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -100,6 +137,25 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		4C0041971BFC382400ED2AD5 /* SQLCipher iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4C00419D1BFC382500ED2AD5 /* Build configuration list for PBXNativeTarget "SQLCipher iOS" */;
+			buildPhases = (
+				4C0041931BFC382400ED2AD5 /* Sources */,
+				4C0041941BFC382400ED2AD5 /* Frameworks */,
+				4C0041951BFC382400ED2AD5 /* Headers */,
+				4C0041961BFC382400ED2AD5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				4C0041A21BFC392D00ED2AD5 /* PBXTargetDependency */,
+			);
+			name = "SQLCipher iOS";
+			productName = SQLCipher;
+			productReference = 4C0041981BFC382400ED2AD5 /* SQLCipher.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		D2AAC045055464E500DB518D /* sqlcipher */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 1DEB91EB08733DB70010E9CD /* Build configuration list for PBXNativeTarget "sqlcipher" */;
@@ -124,7 +180,12 @@
 		08FB7793FE84155DC02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0450;
+				LastUpgradeCheck = 0710;
+				TargetAttributes = {
+					4C0041971BFC382400ED2AD5 = {
+						CreatedOnToolsVersion = 7.1;
+					};
+				};
 			};
 			buildConfigurationList = 1DEB91EF08733DB70010E9CD /* Build configuration list for PBXProject "sqlcipher" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -140,11 +201,22 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
+				4C0041971BFC382400ED2AD5 /* SQLCipher iOS */,
 				D2AAC045055464E500DB518D /* sqlcipher */,
 				9069D08B0FCE185A0042E34C /* amalgamation */,
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		4C0041961BFC382400ED2AD5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
 		9069D08A0FCE185A0042E34C /* ShellScript */ = {
@@ -164,6 +236,13 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		4C0041931BFC382400ED2AD5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D2AAC044055464E500DB518D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -179,6 +258,11 @@
 			isa = PBXTargetDependency;
 			target = 9069D08B0FCE185A0042E34C /* amalgamation */;
 			targetProxy = 289BE0E7180C4930003E52DA /* PBXContainerItemProxy */;
+		};
+		4C0041A21BFC392D00ED2AD5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9069D08B0FCE185A0042E34C /* amalgamation */;
+			targetProxy = 4C0041A11BFC392D00ED2AD5 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -258,6 +342,7 @@
 					x86_64,
 					i386,
 				);
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
@@ -296,6 +381,141 @@
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator macosx iphoneos";
 				VALID_ARCHS = "arm64 armv7 armv7s x86_64 i386";
+			};
+			name = Release;
+		};
+		4C00419E1BFC382500ED2AD5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				"ARCHS[sdk=iphoneos*]" = "$(ARCHS_STANDARD)";
+				"ARCHS[sdk=iphonesimulator*]" = "$(ARCHS_STANDARD)";
+				"ARCHS[sdk=macosx*]" = "$(ARCHS_STANDARD)";
+				BITCODE_GENERATION_MODE = marker;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = macosx/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_CFLAGS = (
+					"-DSQLITE_HAS_CODEC",
+					"-DSQLITE_TEMP_STORE=2",
+					"-DSQLITE_THREADSAFE",
+					"-DSQLCIPHER_CRYPTO_CC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = net.zetetic.SQLCipher;
+				PRODUCT_NAME = SQLCipher;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				VALID_ARCHS = "arm64 armv7 armv7s";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		4C00419F1BFC382500ED2AD5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				"ARCHS[sdk=iphoneos*]" = "$(ARCHS_STANDARD)";
+				"ARCHS[sdk=iphonesimulator*]" = "$(ARCHS_STANDARD)";
+				"ARCHS[sdk=macosx*]" = "$(ARCHS_STANDARD)";
+				BITCODE_GENERATION_MODE = bitcode;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = macosx/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_CFLAGS = (
+					"-DSQLITE_HAS_CODEC",
+					"-DSQLITE_TEMP_STORE=2",
+					"-DSQLITE_THREADSAFE",
+					"-DSQLCIPHER_CRYPTO_CC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = net.zetetic.SQLCipher;
+				PRODUCT_NAME = SQLCipher;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				VALIDATE_PRODUCT = YES;
+				VALID_ARCHS = "arm64 armv7 armv7s";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Release;
 		};
@@ -345,6 +565,14 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		4C00419D1BFC382500ED2AD5 /* Build configuration list for PBXNativeTarget "SQLCipher iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4C00419E1BFC382500ED2AD5 /* Debug */,
+				4C00419F1BFC382500ED2AD5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 		9069D0900FCE18970042E34C /* Build configuration list for PBXAggregateTarget "amalgamation" */ = {
 			isa = XCConfigurationList;

--- a/sqlcipher.xcodeproj/xcshareddata/xcschemes/SQLCipher OSX.xcscheme
+++ b/sqlcipher.xcodeproj/xcshareddata/xcschemes/SQLCipher OSX.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0710"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4C0041B01BFC3B2200ED2AD5"
+               BuildableName = "SQLCipher OSX.framework"
+               BlueprintName = "SQLCipher OSX"
+               ReferencedContainer = "container:sqlcipher.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4C0041B01BFC3B2200ED2AD5"
+            BuildableName = "SQLCipher OSX.framework"
+            BlueprintName = "SQLCipher OSX"
+            ReferencedContainer = "container:sqlcipher.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4C0041B01BFC3B2200ED2AD5"
+            BuildableName = "SQLCipher OSX.framework"
+            BlueprintName = "SQLCipher OSX"
+            ReferencedContainer = "container:sqlcipher.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/sqlcipher.xcodeproj/xcshareddata/xcschemes/SQLCipher iOS.xcscheme
+++ b/sqlcipher.xcodeproj/xcshareddata/xcschemes/SQLCipher iOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0710"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4C0041971BFC382400ED2AD5"
+               BuildableName = "SQLCipher.framework"
+               BlueprintName = "SQLCipher iOS"
+               ReferencedContainer = "container:sqlcipher.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4C0041971BFC382400ED2AD5"
+            BuildableName = "SQLCipher.framework"
+            BlueprintName = "SQLCipher iOS"
+            ReferencedContainer = "container:sqlcipher.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4C0041971BFC382400ED2AD5"
+            BuildableName = "SQLCipher.framework"
+            BlueprintName = "SQLCipher iOS"
+            ReferencedContainer = "container:sqlcipher.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/sqlcipher.xcodeproj/xcshareddata/xcschemes/SQLCipher tvOS.xcscheme
+++ b/sqlcipher.xcodeproj/xcshareddata/xcschemes/SQLCipher tvOS.xcscheme
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "4C0041B01BFC3B2200ED2AD5"
-               BuildableName = "SQLCipher.framework"
-               BlueprintName = "SQLCipher OSX"
+               BlueprintIdentifier = "4C0041C21BFC3CC000ED2AD5"
+               BuildableName = "SQLCipher tvOS.framework"
+               BlueprintName = "SQLCipher tvOS"
                ReferencedContainer = "container:sqlcipher.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -45,9 +45,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "4C0041B01BFC3B2200ED2AD5"
-            BuildableName = "SQLCipher.framework"
-            BlueprintName = "SQLCipher OSX"
+            BlueprintIdentifier = "4C0041C21BFC3CC000ED2AD5"
+            BuildableName = "SQLCipher tvOS.framework"
+            BlueprintName = "SQLCipher tvOS"
             ReferencedContainer = "container:sqlcipher.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -63,9 +63,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "4C0041B01BFC3B2200ED2AD5"
-            BuildableName = "SQLCipher.framework"
-            BlueprintName = "SQLCipher OSX"
+            BlueprintIdentifier = "4C0041C21BFC3CC000ED2AD5"
+            BuildableName = "SQLCipher tvOS.framework"
+            BlueprintName = "SQLCipher tvOS"
             ReferencedContainer = "container:sqlcipher.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/sqlcipher.xcodeproj/xcshareddata/xcschemes/SQLCipher watchOS.xcscheme
+++ b/sqlcipher.xcodeproj/xcshareddata/xcschemes/SQLCipher watchOS.xcscheme
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "4C0041C21BFC3CC000ED2AD5"
-               BuildableName = "SQLCipher.framework"
-               BlueprintName = "SQLCipher tvOS"
+               BlueprintIdentifier = "4C0041D51BFC3E2500ED2AD5"
+               BuildableName = "SQLCipher watchOS.framework"
+               BlueprintName = "SQLCipher watchOS"
                ReferencedContainer = "container:sqlcipher.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -45,9 +45,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "4C0041C21BFC3CC000ED2AD5"
-            BuildableName = "SQLCipher.framework"
-            BlueprintName = "SQLCipher tvOS"
+            BlueprintIdentifier = "4C0041D51BFC3E2500ED2AD5"
+            BuildableName = "SQLCipher watchOS.framework"
+            BlueprintName = "SQLCipher watchOS"
             ReferencedContainer = "container:sqlcipher.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -63,9 +63,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "4C0041C21BFC3CC000ED2AD5"
-            BuildableName = "SQLCipher.framework"
-            BlueprintName = "SQLCipher tvOS"
+            BlueprintIdentifier = "4C0041D51BFC3E2500ED2AD5"
+            BuildableName = "SQLCipher watchOS.framework"
+            BlueprintName = "SQLCipher watchOS"
             ReferencedContainer = "container:sqlcipher.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/sqlcipher.xcodeproj/xcshareddata/xcschemes/SQLCipher watchOS.xcscheme
+++ b/sqlcipher.xcodeproj/xcshareddata/xcschemes/SQLCipher watchOS.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "4C0041D51BFC3E2500ED2AD5"
-               BuildableName = "SQLCipher watchOS.framework"
+               BuildableName = "SQLCipher.framework"
                BlueprintName = "SQLCipher watchOS"
                ReferencedContainer = "container:sqlcipher.xcodeproj">
             </BuildableReference>
@@ -46,7 +46,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "4C0041D51BFC3E2500ED2AD5"
-            BuildableName = "SQLCipher watchOS.framework"
+            BuildableName = "SQLCipher.framework"
             BlueprintName = "SQLCipher watchOS"
             ReferencedContainer = "container:sqlcipher.xcodeproj">
          </BuildableReference>
@@ -64,7 +64,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "4C0041D51BFC3E2500ED2AD5"
-            BuildableName = "SQLCipher watchOS.framework"
+            BuildableName = "SQLCipher.framework"
             BlueprintName = "SQLCipher watchOS"
             ReferencedContainer = "container:sqlcipher.xcodeproj">
          </BuildableReference>


### PR DESCRIPTION
The following PR adds new frameworks with all the bells and whistles for iOS 8.0+, OS X 10.9+, tvOS 9.0+ and watchOS 2.0+. It closely mimics the [Alamofire](https://github.com/Alamofire/Alamofire) Xcode project that I maintain if you would like to use that as a reference to compare against. It has all the smalls tweaks from that project that we've had to make alongside Carthage updates, tvOS idiosyncrasies, etc. I've gone through them all VERY closely and everything builds nicely.

This should make it MUCH easier for those of us in the Swift community to use SQLCipher in our apps and third party libraries. 🙌🏼 🙌🏼 🙌🏼