### PR TITLE
Fix debug build with CommonCrypto

### DIFF
--- a/src/crypto_cc.c
+++ b/src/crypto_cc.c
@@ -90,7 +90,6 @@ static int sqlcipher_cc_cipher(void *ctx, int mode, unsigned char *key, int key_
   CCCryptorFinal(cryptor, out, in_sz - csz, &tmp_csz);
   csz += tmp_csz;
   CCCryptorRelease(cryptor);
-  assert(size == csz);
 
   return SQLITE_OK; 
 }


### PR DESCRIPTION
There is an invalid assert on line 93 of src/crypto_cc.c. This *only* breaks a debug build. I encountered this when integrating SQLCipher 3.4.0 with Cordova since it is using a custom project **instead of sqlcipher.xcodeproj**. (Apparently I have to explicitly define `NDEBUG` to disable the debug build in my custom project.)

This would also be an issue when testing a debug build with CommonCrypto on a Mac system.

The solution proposed here is to simply remove the invalid assert.