### PR TITLE
For review: option to use fopen_s in src/crypto_impl.c for WinRT build

### DIFF
--- a/src/crypto_impl.c
+++ b/src/crypto_impl.c
@@ -1210,10 +1210,16 @@ int sqlcipher_cipher_profile(sqlite3 *db, const char *destination){
   }else if( strcmp(destination, "off")==0 ){
     f = 0;
   }else{
+#ifdef SQLITE_CODEC_SAFE_OPEN
+    if( fopen_s(&f, destination, "wb")!=0 ){
+      return SQLITE_ERROR;
+    }
+#else
     f = fopen(destination, "wb");
     if( f==0 ){
       return SQLITE_ERROR;
     }
+#endif
   }
   sqlite3_profile(db, sqlcipher_profile_callback, f);
   return SQLITE_OK;


### PR DESCRIPTION
I encountered an issue where I had to use `fopen_s` instead of `fopen` in `src/crypto_impl.c` when building for WinRT targets (such as Windows 8.1/Windows Phone 8.1/Windows 10). While I think it is possible to define a compiler flag to enable unsafe operations, I find it easier to simply use `fopen_s` when building for a WinRT target. What is very strange is that I do not encounter this issue 100% of the time.

The change proposed here is to add an `#ifdef SQLITE_CODEC_SAFE_OPEN` option to `src/crypto_impl.c` that would use `fopen_s` if this option is defined.

I will understand if this proposal is not accepted. I submit this proposal in case it may help someone else.

UPDATE: I have tested the prerelease with this change in my Cordova plugin.