### PR TITLE
Fix building with libressl

### DIFF
--- a/src/crypto_openssl.c
+++ b/src/crypto_openssl.c
@@ -47,7 +47,7 @@ static unsigned int openssl_external_init = 0;
 static unsigned int openssl_init_count = 0;
 static sqlite3_mutex* openssl_rand_mutex = NULL;
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 static HMAC_CTX *HMAC_CTX_new(void)
 {
   HMAC_CTX *ctx = OPENSSL_malloc(sizeof(*ctx));


### PR DESCRIPTION
Now - to prerelease branch, as told here - https://github.com/sqlcipher/sqlcipher/pull/227

Fix coming from Gentoo bugreport - https://bugs.gentoo.org/show_bug.cgi?id=622114