### PR TITLE
Changed sqlcipher_codec_ctx_migrate to use VFS xDelete instead of sta…

### DIFF
--- a/src/crypto_impl.c
+++ b/src/crypto_impl.c
@@ -1165,7 +1165,7 @@ int sqlcipher_codec_ctx_migrate(codec_ctx *ctx) {
       pDb->pBt = 0;
       pDb->pSchema = 0;
       sqlite3ResetAllSchemasOfConnection(db);
-      remove(migrated_db_filename);
+      db->pVfs->xDelete(db->pVfs, migrated_db_filename, 0);
       sqlite3_free(migrated_db_filename);
     } else {
       CODEC_TRACE(("*** migration failure** \n\n"));


### PR DESCRIPTION
sqlcipher_codec_ctx_migrate had a direct reference to the C library remove function
Changed it to use the VFS xDelete for platforms where the standard remove might not be available

…ndard library remove

Changes proposed in this pull request:
-
