### PR TITLE
Fix building with libressl (again)

### DIFF
--- a/src/crypto_openssl.c
+++ b/src/crypto_openssl.c
@@ -117,7 +117,7 @@ static int sqlcipher_openssl_activate(void *ctx) {
 
   if(openssl_init_count == 0 && openssl_external_init == 0)  {
     /* if the library was not externally initialized, then should be now */
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
     OpenSSL_add_all_algorithms();
 #endif
   } 
@@ -154,7 +154,7 @@ static int sqlcipher_openssl_deactivate(void *ctx) {
        Note: this code will only be reached if OpensSSL_add_all_algorithms()
        is called by SQLCipher internally. This should prevent SQLCipher from 
        "cleaning up" openssl when it was initialized externally by the program */
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
       EVP_cleanup();
 #endif
     } else {


### PR DESCRIPTION
Broken by 1c495b933cee3381f1ea6a70edcbcda1754d7409

Changes proposed in this pull request:
- Fixes the incompatibility with LibreSSL in sqlcipher 3.4.2