### PR TITLE
Fix build error when enabled CODEC_DEBUG

### DIFF
--- a/src/crypto_impl.c
+++ b/src/crypto_impl.c
@@ -1087,10 +1087,10 @@ error:
 static int sqlcipher_cipher_ctx_key_derive(codec_ctx *ctx, cipher_ctx *c_ctx) {
   int rc;
   CODEC_TRACE("cipher_ctx_key_derive: entered c_ctx->pass=%s, c_ctx->pass_sz=%d \
-                ctx->kdf_salt=%p ctx->kdf_salt_sz=%d c_ctx->kdf_iter=%d \
-                ctx->hmac_kdf_salt=%p, c_ctx->fast_kdf_iter=%d ctx->key_sz=%d\n", 
-                c_ctx->pass, c_ctx->pass_sz, ctx->kdf_salt, ctx->kdf_salt_sz, c_ctx->kdf_iter, 
-                ctx->hmac_kdf_salt, c_ctx->fast_kdf_iter, ctx->key_sz); 
+                ctx->kdf_salt=%p ctx->kdf_salt_sz=%d ctx->kdf_iter=%d \
+                ctx->hmac_kdf_salt=%p, ctx->fast_kdf_iter=%d ctx->key_sz=%d\n", 
+                c_ctx->pass, c_ctx->pass_sz, ctx->kdf_salt, ctx->kdf_salt_sz, ctx->kdf_iter, 
+                ctx->hmac_kdf_salt, ctx->fast_kdf_iter, ctx->key_sz); 
                 
   
   if(c_ctx->pass && c_ctx->pass_sz) { // if pass is not null
@@ -1110,7 +1110,7 @@ static int sqlcipher_cipher_ctx_key_derive(codec_ctx *ctx, cipher_ctx *c_ctx) {
       cipher_hex2bin(z, (ctx->key_sz * 2), c_ctx->key);
       cipher_hex2bin(z + (ctx->key_sz * 2), (ctx->kdf_salt_sz * 2), ctx->kdf_salt);
     } else { 
-      CODEC_TRACE("cipher_ctx_key_derive: deriving key using full PBKDF2 with %d iterations\n", c_ctx->kdf_iter); 
+      CODEC_TRACE("cipher_ctx_key_derive: deriving key using full PBKDF2 with %d iterations\n", ctx->kdf_iter); 
       if(ctx->provider->kdf(ctx->provider_ctx, ctx->kdf_algorithm, c_ctx->pass, c_ctx->pass_sz, 
                     ctx->kdf_salt, ctx->kdf_salt_sz, ctx->kdf_iter,
                     ctx->key_sz, c_ctx->key) != SQLITE_OK) return SQLITE_ERROR;
@@ -1136,7 +1136,7 @@ static int sqlcipher_cipher_ctx_key_derive(codec_ctx *ctx, cipher_ctx *c_ctx) {
       } 
 
       CODEC_TRACE("cipher_ctx_key_derive: deriving hmac key from encryption key using PBKDF2 with %d iterations\n", 
-        c_ctx->fast_kdf_iter); 
+        ctx->fast_kdf_iter); 
 
       
       if(ctx->provider->kdf(ctx->provider_ctx, ctx->kdf_algorithm, c_ctx->key, ctx->key_sz, 


### PR DESCRIPTION
Fix build errors.

## How to reproduce

```
./configure --enable-tempstore=yes CFLAGS="-DSQLITE_HAS_CODEC -DCODEC_DEBUG" LDFLAGS="-L/path/to/openssl"
make
```
## Description

CODEC_TRACE macro is compiled when enabled CODEC_DEBUG. However, some expressions specified in the argument indicate invalid members. ```kdf_iter``` and ```fast_kdf_iter``` are not defined in cipher_ctx. They are defined in codec_ctx.


