### PR TITLE
fix lemon to lemon$(BEXE) in fts5parse.c dependencies

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1215,7 +1215,7 @@ FTS5_SRC = \
    $(TOP)/ext/fts5/fts5_varint.c \
    $(TOP)/ext/fts5/fts5_vocab.c  \
 
-fts5parse.c:	$(TOP)/ext/fts5/fts5parse.y lemon
+fts5parse.c:	$(TOP)/ext/fts5/fts5parse.y lemon$(BEXE)
 	cp $(TOP)/ext/fts5/fts5parse.y .
 	rm -f fts5parse.h
 	./lemon$(BEXE) $(OPTS) fts5parse.y


### PR DESCRIPTION
<!--
Make sure that your pull request is based on the `prerelease` branch.
-->

Changes proposed in this pull request:
-
Compiling sqlcipher for mingw currently fails due to the missing `$(BEXE)` in Makefile.in