### PR TITLE
Fix wrong/missing return value check of mmap function

### DIFF
--- a/ext/lsm1/lsm_unix.c
+++ b/ext/lsm1/lsm_unix.c
@@ -228,6 +228,12 @@ static int lsmPosixOsRemap(
     }
 
     p->pMap = mmap(0, iSz, PROT_READ|PROT_WRITE, MAP_SHARED, p->fd, 0);
+
+    if( p->pMap==MAP_FAILED ){
+        p->pMap = 0;
+        return LSM_IOERR_BKPT;
+    }
+
     p->nMap = iSz;
   }
 
@@ -413,7 +419,11 @@ static int lsmPosixOsShmMap(lsm_file *pFile, int iChunk, int sz, void **ppShm){
     p->apShm[iChunk] = mmap(0, LSM_SHM_CHUNK_SIZE, 
         PROT_READ|PROT_WRITE, MAP_SHARED, p->shmfd, iChunk*LSM_SHM_CHUNK_SIZE
     );
-    if( p->apShm[iChunk]==0 ) return LSM_IOERR_BKPT;
+
+    if( p->apShm[iChunk]==MAP_FAILED ){
+        p->apShm[iChunk] = 0;
+        return LSM_IOERR_BKPT;
+    }
   }
 
   *ppShm = p->apShm[iChunk];


### PR DESCRIPTION
The mmap function returns MAP_FAILED (-1) on error not 0. This pull request adds a missing return value check and fixes a wrong return value check of the mmap function. After an mmap error the pointer is set to 0, because this is the default value.

Bug found by using the following simple script: https://github.com/hannob/mmapfail