### PR TITLE
Free allocated EVP_MAC

### DIFF
--- a/src/crypto_openssl.c
+++ b/src/crypto_openssl.c
@@ -326,6 +326,7 @@ cleanup:
   if(hctx) HMAC_CTX_free(hctx);
 #else
   if(hctx) EVP_MAC_CTX_free(hctx);
+  if(mac) EVP_MAC_free(mac);
 #endif
   return rc;
 }


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix regression from 58b3acc730eec3d6c65ff23913e2df345f36e6e6 with `EVP_MAC mac` not freed
