### PR TITLE
Disable malloc_usable_size

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -108,7 +108,7 @@ AC_CHECK_HEADERS([sys/types.h stdlib.h stdint.h inttypes.h malloc.h])
 #########
 # Figure out whether or not we have these functions
 #
-AC_CHECK_FUNCS([fdatasync gmtime_r isnan localtime_r localtime_s malloc_usable_size strchrnul usleep utime pread pread64 pwrite pwrite64])
+AC_CHECK_FUNCS([fdatasync gmtime_r isnan localtime_r localtime_s strchrnul usleep utime pread pread64 pwrite pwrite64])
 
 #########
 # By default, we use the amalgamation (this may be changed below...)


### PR DESCRIPTION
Disable code introduced in sqlite 3.7.10 using malloc_usable_size, as it caused a regression on 64-bit platforms.

Patch by Steven Chamberlain <steven@pyro.eu.org> from http://bugs.debian.org/665363 .

Patch has been used by Debian package for a while, see https://udd.debian.org/patches.cgi?src=sqlcipher&version=3.4.1-2 .