### PR TITLE
sqliteInt.h: fix pointer size for ppc64

### DIFF
--- a/src/sqliteInt.h
+++ b/src/sqliteInt.h
@@ -873,7 +873,7 @@ typedef INT16_TYPE LogEst;
 #   define SQLITE_PTRSIZE __SIZEOF_POINTER__
 # elif defined(i386)     || defined(__i386__)   || defined(_M_IX86) ||    \
        defined(_M_ARM)   || defined(__arm__)    || defined(__x86)   ||    \
-      (defined(__APPLE__) && defined(__POWERPC__)) ||                     \
+      (defined(__APPLE__) && defined(__ppc__))  ||                        \
       (defined(__TOS_AIX__) && !defined(__64BIT__))
 #   define SQLITE_PTRSIZE 4
 # else


### PR DESCRIPTION
Exiting code has an effect of defining pointer size on macOS `ppc64` to 4 bytes which is wrong. `__POWERPC__` define encompasses both 32- and 64-bit versions, so what should be used is `__ppc__` instead.