### PR TITLE
Fix broken SQLCIPHER_OMIT_LOG

### DIFF
--- a/src/crypto_impl.c
+++ b/src/crypto_impl.c
@@ -1679,7 +1679,9 @@ const char* sqlcipher_codec_get_provider_version(codec_ctx *ctx) {
   return ctx->provider->get_provider_version(ctx->provider_ctx);
 }
 
-#ifndef SQLCIPHER_OMIT_LOG
+#ifdef SQLCIPHER_OMIT_LOG
+void sqlcipher_log(unsigned int level, const char *message, ...) {}
+#else
 /* constants from https://github.com/Alexpux/mingw-w64/blob/master/mingw-w64-crt/misc/gettimeofday.c */
 #define FILETIME_1970 116444736000000000ull /* seconds between 1/1/1601 and 1/1/1970 */
 #define HECTONANOSEC_PER_SEC 10000000ull


### PR DESCRIPTION
By creating empty stub for sqlcipher_log.

<!--
Make sure that your pull request is based on the `prerelease` branch.
-->

Changes proposed in this pull request:
-
