### PR TITLE
Update PrivacyInfo.xcprivacy: Remove invalid CollectedDataTypes

### DIFF
--- a/sqlcipher-resources/PrivacyInfo.xcprivacy
+++ b/sqlcipher-resources/PrivacyInfo.xcprivacy
@@ -4,18 +4,6 @@
 <dict>
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array>
-		<dict>
-			<key>NSPrivacyCollectedDataType</key>
-			<string></string>
-			<key>NSPrivacyCollectedDataTypeLinked</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypeTracking</key>
-			<false/>
-			<key>NSPrivacyCollectedDataTypePurposes</key>
-			<array>
-				<string></string>
-			</array>
-		</dict>
 	</array>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>


### PR DESCRIPTION
<!--
Make sure that your pull request is based on the `prerelease` branch.
-->

Changes proposed in this pull request:
-
Remove invalid CollectedDataTypes in xcprivacy file because NSPrivacyCollectedDataType is empty, mean we don't collect any data