### PR TITLE
xoshiro should use sqlite_uint64 instead of uint64_t

### DIFF
--- a/src/sqlcipher.c
+++ b/src/sqlcipher.c
@@ -208,15 +208,15 @@ struct private_block {
  * https://prng.di.unimi.it/ under the public domain via https://prng.di.unimi.it/xoshiro256plusplus.c
  * xoshiro is NEVER used for any cryptographic functions as CSPRNG. It is solely used for
  * generating random data for testing, debugging, and forensic purposes (overwriting memory segments) */
-static volatile uint64_t xoshiro_s[4];
+static volatile sqlite_uint64 xoshiro_s[4];
 
-static inline uint64_t xoshiro_rotl(const uint64_t x, int k) {
+static inline sqlite_uint64 xoshiro_rotl(const sqlite_uint64 x, int k) {
   return (x << k) | (x >> (64 - k));
 }
 
-uint64_t xoshiro_next(void) {
-  volatile uint64_t result = xoshiro_rotl(xoshiro_s[0] + xoshiro_s[3], 23) + xoshiro_s[0];
-  volatile uint64_t t = xoshiro_s[1] << 17;
+sqlite_uint64 xoshiro_next(void) {
+  volatile sqlite_uint64 result = xoshiro_rotl(xoshiro_s[0] + xoshiro_s[3], 23) + xoshiro_s[0];
+  volatile sqlite_uint64 t = xoshiro_s[1] << 17;
 
   xoshiro_s[2] ^= xoshiro_s[0];
   xoshiro_s[3] ^= xoshiro_s[1];
@@ -231,7 +231,7 @@ uint64_t xoshiro_next(void) {
 }
 
 static void xoshiro_randomness(unsigned char *ptr, int sz) {
-  volatile uint64_t val;
+  volatile sqlite_uint64 val;
   volatile int to_copy;
   while (sz > 0) {
     val = xoshiro_next();


### PR DESCRIPTION
The various xoshiro256++ PSRNG functions added in https://github.com/sqlcipher/sqlcipher/commit/bf1b1d3c54a81758bd60fcdbfaa71a9797cdfbe0 should be using `sqlite_uint64` instead of `uint64_t`, since the latter type may not be defined in all configuration variations.

This was causing build errors for us on Windows and Linux (but not macOS/iOS/Android) when we upgraded to SQLCipher 4.7.0 (https://github.com/skiptools/swift-sqlcipher/pull/5).

Linux errors:

```
/home/runner/work/swift-sqlcipher/swift-sqlcipher/Sources/SQLCipher/sqlite/sqlite3.c:107714:17: error: unknown type name 'uint64_t'
 107714 | static volatile uint64_t xoshiro_s[4];
        |                 ^
/home/runner/work/swift-sqlcipher/swift-sqlcipher/Sources/SQLCipher/sqlite/sqlite3.c:107716:15: error: unknown type name 'uint64_t'
 107716 | static inline uint64_t xoshiro_rotl(const uint64_t x, int k) {
        |               ^
/home/runner/work/swift-sqlcipher/swift-sqlcipher/Sources/SQLCipher/sqlite/sqlite3.c:107716:43: error: unknown type name 'uint64_t'
 107716 | static inline uint64_t xoshiro_rotl(const uint64_t x, int k) {
        |                                           ^
/home/runner/work/swift-sqlcipher/swift-sqlcipher/Sources/SQLCipher/sqlite/sqlite3.c:107720:1: error: unknown type name 'uint64_t'
 107720 | uint64_t xoshiro_next(void) {
        | ^
/home/runner/work/swift-sqlcipher/swift-sqlcipher/Sources/SQLCipher/sqlite/sqlite3.c:107721:12: error: unknown type name 'uint64_t'
 107721 |   volatile uint64_t result = xoshiro_rotl(xoshiro_s[0] + xoshiro_s[3], 23) + xoshiro_s[0];
        |            ^
/home/runner/work/swift-sqlcipher/swift-sqlcipher/Sources/SQLCipher/sqlite/sqlite3.c:107722:12: error: unknown type name 'uint64_t'
 107722 |   volatile uint64_t t = xoshiro_s[1] << 17;
        |            ^
/home/runner/work/swift-sqlcipher/swift-sqlcipher/Sources/SQLCipher/sqlite/sqlite3.c:107737:12: error: unknown type name 'uint64_t'
 107737 |   volatile uint64_t val;
        |            ^
```


Windows errors:

```
D:\a\swift-sqlcipher\swift-sqlcipher\Sources\SQLCipher\sqlite\sqlite3.c:107714:17: error: unknown type name 'uint64_t'

static volatile uint64_t xoshiro_s[4];

                ^

D:\a\swift-sqlcipher\swift-sqlcipher\Sources\SQLCipher\sqlite\sqlite3.c:107716:15: error: unknown type name 'uint64_t'

static inline uint64_t xoshiro_rotl(const uint64_t x, int k) {

              ^

D:\a\swift-sqlcipher\swift-sqlcipher\Sources\SQLCipher\sqlite\sqlite3.c:107716:43: error: unknown type name 'uint64_t'

static inline uint64_t xoshiro_rotl(const uint64_t x, int k) {

                                          ^

D:\a\swift-sqlcipher\swift-sqlcipher\Sources\SQLCipher\sqlite\sqlite3.c:107720:1: error: unknown type name 'uint64_t'

uint64_t xoshiro_next(void) {

^

D:\a\swift-sqlcipher\swift-sqlcipher\Sources\SQLCipher\sqlite\sqlite3.c:107721:12: error: unknown type name 'uint64_t'

  volatile uint64_t result = xoshiro_rotl(xoshiro_s[0] + xoshiro_s[3], 23) + xoshiro_s[0];

           ^

D:\a\swift-sqlcipher\swift-sqlcipher\Sources\SQLCipher\sqlite\sqlite3.c:107722:12: error: unknown type name 'uint64_t'

  volatile uint64_t t = xoshiro_s[1] << 17;

           ^

D:\a\swift-sqlcipher\swift-sqlcipher\Sources\SQLCipher\sqlite\sqlite3.c:107737:12: error: unknown type name 'uint64_t'

  volatile uint64_t val;

           ^
```

