### PR TITLE
Fix #ifdefs for SQLITE_HAS_CODEC

### DIFF
--- a/src/ctime.c
+++ b/src/ctime.c
@@ -383,7 +383,7 @@ static const char * const sqlite3azCompileOpt[] = {
   "FTS5_NO_WITHOUT_ROWID",
 #endif
 /* BEGIN SQLCIPHER */
-#if SQLITE_HAS_CODEC
+#ifdef SQLITE_HAS_CODEC
   "HAS_CODEC",
 #endif
 /* END SQLCIPHER */

--- a/src/pager.c
+++ b/src/pager.c
@@ -2566,7 +2566,7 @@ static int pager_playback_one_page(
 
     /* Decode the page just read from disk */
 /* BEGIN SQLCIPHER */
-#if SQLITE_HAS_CODEC
+#ifdef SQLITE_HAS_CODEC
     if( jrnlEnc ){ CODEC1(pPager, pData, pPg->pgno, 3, rc=SQLITE_NOMEM_BKPT); }
 #endif
 /* END SQLCIPHER */
@@ -4646,7 +4646,7 @@ static int subjournalPage(PgHdr *pPg){
       char *pData2;
 
 /* BEGIN SQLCIPHER */
-#if SQLITE_HAS_CODEC   
+#ifdef SQLITE_HAS_CODEC   
       if( !pPager->subjInMemory ){
         CODEC2(pPager, pData, pPg->pgno, 7, return SQLITE_NOMEM_BKPT, pData2);
       }else


### PR DESCRIPTION
Fixes build errors when building with just `-DSQLITE_HAS_CODEC` (which most examples use) instead of e.g. `-DSQLITE_HAS_CODEC=1`.