### PR TITLE
Fallback gcc compiler when not finding cross compiler triplet

### DIFF
--- a/autosetup/cc.tcl
+++ b/autosetup/cc.tcl
@@ -692,6 +692,9 @@ proc cc-init {} {
 	} else {
 		# Try some reasonable options
 		set try [list [get-define cross]cc [get-define cross]gcc]
+		if {[get-define cross] ne ""} {
+			lappend try gcc cc
+		}
 	}
 	define CC [find-an-executable {*}$try]
 	if {[get-define CC] eq ""} {


### PR DESCRIPTION
Hello! :wave: 

This PR adds a new rule to autosetup when cross-building and not finding the expected compiler with the configured host triplet: It tries to use the regular gcc instead, as previously seen in SQLCipher 4.6.1.

It prevents missing cross-compilation on Mac, as the regular Apple Clang compiler is capable to cross build by only using `-arch` flag.

Fixes #593

