### PR TITLE
Fix Windows stack-overflow recursion between the log sink and the memory-security allocator

### DIFF
--- a/src/sqlcipher.c
+++ b/src/sqlcipher.c
@@ -2577,11 +2577,40 @@ static char *sqlcipher_get_log_sources_str(unsigned int source) {
 #define FILETIME_1970 116444736000000000ull /* seconds between 1/1/1601 and 1/1/1970 */
 #define HECTONANOSEC_PER_SEC 10000000ull
 #define MAX_LOG_LEN 8192
+
+#ifdef _WIN32
+#ifdef _MSC_VER
+#define SQLCIPHER_TLS __declspec(thread)
+#else
+#define SQLCIPHER_TLS __thread
+#endif
+/* Guards against unbounded same-thread reentrancy through the console log
+   sink. On Windows, sqlcipher_fprintf converts messages to UTF-16 by
+   allocating through sqlite3_vmprintf and sqlite3_malloc. When
+   cipher_memory_security is enabled those allocations go through the locked
+   allocator, whose VirtualLock call can fail once the process working-set
+   quota is exhausted (commonly observed as "VirtualLock() returned 0
+   LastError=1453"). That failure is itself logged, and writing the warning
+   allocates again, fails again, and logs again, recursing until the stack
+   overflows. Messages emitted while this thread is already inside
+   sqlcipher_log are therefore dropped. */
+static SQLCIPHER_TLS int sqlcipher_log_active = 0;
+#endif
+
 void sqlcipher_log(unsigned int level, unsigned int source, const char *message, ...) {
   va_list params;
-  va_start(params, message);
   char formatted[MAX_LOG_LEN];
   size_t len = 0;
+
+#ifdef _WIN32
+  if(sqlcipher_log_active) {
+    /* re-entered from within the log sink's own allocation path */
+    return;
+  }
+  sqlcipher_log_active = 1;
+#endif
+
+  va_start(params, message);
 
 #ifdef CODEC_DEBUG
 #if defined(SQLCIPHER_OMIT_LOG_DEVICE) || (!defined(__ANDROID__) && !defined(__APPLE__))
@@ -2653,6 +2682,9 @@ void sqlcipher_log(unsigned int level, unsigned int source, const char *message,
 
 end:
   va_end(params);
+#ifdef _WIN32
+  sqlcipher_log_active = 0;
+#endif
 }
 #endif
 


### PR DESCRIPTION
## Summary

On Windows, enabling `PRAGMA cipher_memory_security = ON` can crash the process with `STATUS_STACK_OVERFLOW` through unbounded mutual recursion between the logger and the locked allocator:

1. The default log configuration is level `WARN` to `stderr`.
2. `cipher_memory_security` routes every `sqlite3_malloc` through the locked allocator, and `sqlcipher_mlock` logs a `WARN` whenever `VirtualLock` fails — commonly `VirtualLock() returned 0 LastError=1453` (`ERROR_WORKING_SET_QUOTA`), the known-benign condition discussed in https://discuss.zetetic.net/t/errors-with-mlock-virtuallock-in-ci-cd-pipelines/6704.
3. On Windows the console sink, `sqlcipher_fprintf`, converts the message to UTF-16 by allocating through `sqlite3_vmprintf` and `sqlite3_malloc` — the same locked allocator.
4. That allocation fails `VirtualLock` again, logs again, and the cycle repeats until the stack is exhausted.

Unix, Android, and Apple never loop: their sinks write with plain `fprintf` or the device logger and do not allocate through `sqlite3_malloc`.

The crash needs an allocation larger than the pre-locked startup heap (4.7.0's 48KB pool absorbs small ones) while the working-set quota is exhausted — for example preparing a moderately large `CREATE TABLE` on a busy machine or CI runner. Because the trigger is quota exhaustion, raising thread stack sizes does not help; we reproduced the crash with a 256 MiB stack.

## Fix

Drop messages emitted while the same thread is already inside `sqlcipher_log`, via a Windows-only thread-local guard (`__declspec(thread)` on MSVC, `__thread` on MinGW). The recursion is same-thread by construction, so a thread-local flag is exactly sufficient, costs nothing on the hot path, and changes no behavior other than suppressing the infinitely-repeating message that was killing the process.

## Reproduction

Observed with SQLCipher 4.14.0 community (via Rust `libsqlite3-sys` 0.38.1, vendored OpenSSL, MSVC) on `windows-2025` GitHub runners, and present unchanged at current `master`. Steps:

1. Open a file database, `PRAGMA key`, `PRAGMA cipher_memory_security = ON`, leave log settings at their defaults.
2. Prepare a schema batch of a few KB (several `CREATE TABLE` statements with `CHECK` constraints).
3. On a process whose working set is near its quota, the process dies with `STATUS_STACK_OVERFLOW` (exit 0xc00000fd) inside the prepare.

Under the same conditions the crash disappears with any one of: `cipher_memory_security` off, `PRAGMA cipher_log_level = NONE`, or pre-growing the working set with `SetProcessWorkingSetSize` — the last of which confirmed the quota mechanism.

The patched amalgamation compiles cleanly; the non-Windows paths are unchanged.

